### PR TITLE
Reduce Mint version strictness

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule LogflareApiClient.MixProject do
     [
       {:tesla, "~> 1.4.0"},
       {:jason, ">= 1.0.0"},
-      {:mint, "~> 1.3.0"},
+      {:mint, "~> 1.3"},
       {:finch, "~> 0.8"},
       {:castore, "~> 0.1"},
       {:bertex, "~> 1.3"},


### PR DESCRIPTION
Due to the fact this lib uses such a strict versioning of Mint other libraries clash with it (e.g. Tesla).

Example of failure when adding to existing project:
```
Failed to use "mint" (version 1.4.2) because
  finch (version 0.13.0) requires ~> 1.3
  logflare_api_client (version 0.3.2) requires ~> 1.3.0
  tesla (version 1.4.4) requires ~> 1.0
  mix.lock specifies 1.4.2
```