### PR TITLE
Remove mint and castore from deps and relax finch

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -33,9 +33,7 @@ defmodule LogflareApiClient.MixProject do
     [
       {:tesla, "~> 1.4.0"},
       {:jason, ">= 1.0.0"},
-      {:mint, "~> 1.4.0"},
-      {:finch, "~> 0.10.2"},
-      {:castore, "~> 0.1.17"},
+      {:finch, "~> 0.10"},
       {:bertex, "~> 1.3"},
       {:bypass, "~> 2.1", only: :test},
       {:mix_test_watch, "~> 1.0", only: :dev, runtime: false},


### PR DESCRIPTION
This helps resolves some dependency hell.

1. you're using Finch which has its own dep on mint, so you may not need to restrict Mint versions yourself.
1. you're using Finch which has its own dep on castore, so you may not need to restrict castore versions yourself.
1. Pinning Finch to 0.10.x doesn't seem to be necessary. Finch 0.11 has breaking changes for renaming telemetry events, but I don't see that you're using those so it should be ok.